### PR TITLE
fix infinite spawning servers

### DIFF
--- a/task.php
+++ b/task.php
@@ -21,7 +21,7 @@ class Task {
 	}
 
 	public function schedule() {
-		delete_transient( 'hm_backdrop-' . $this->key );
+
 		if ( $this->is_scheduled() ) {
 			return new WP_Error( 'hm_backdrop_scheduled', __( 'Task is already scheduled to run', 'hm_backdrop' ) );
 		}


### PR DESCRIPTION
So I think I have found the culprit for my infinite spawning backdrop servers... I think this shouln't be here :wink: 

I think your current unique ID works correctly as serializing `$this` only uses properties, so it doesn't change every time.
