### PR TITLE
Limit the key length so we avoid going over the transient name limit

### DIFF
--- a/task.php
+++ b/task.php
@@ -70,6 +70,6 @@ class Task {
 	}
 
 	protected function get_unique_id() {
-		return substr( sha1( serialize( $this->callback ) . serialize( $this->params ) ), -33 );
+		return substr( sha1( serialize( $this->callback ) . serialize( $this->params ) ), -28 );
 	}
 }


### PR DESCRIPTION
The `option_name` column is `VARCHAR 64`.

In practise this means transient names should be no longer than 40 characters.

From http://codex.wordpress.org/Transients_API#Using_Transients

> `(string)` a unique identifier for your cached data (this should be 45 characters or less in length.. NOTE: if using a site transient, it should be 40 characters or less in length)

Trac ticket http://core.trac.wordpress.org/ticket/15058

Given `get_unique_id` uses `sha1` which returns a 40 character string which in turn is then concatenated onto `hm_backdrop-`. This creates a string which is 62 characters long.

Solution is to ensure `get_unique_id` only returns a string that is 28 characters long.
