### PR TITLE
Don't verify local SSL connections

### DIFF
--- a/task.php
+++ b/task.php
@@ -55,7 +55,7 @@ class HM_Backdrop_Task {
 			'body' => $data,
 			'timeout' => 0.01,
 			'blocking' => false,
-			'sslverify' => apply_filters( 'https_local_ssl_verify', true ),
+			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
 		);
 		wp_remote_post( $server_url, $args );
 		return true;


### PR DESCRIPTION
This [changed recently in WordPress](https://core.trac.wordpress.org/changeset/28781) so we might as well follow suit here.

See also https://github.com/wp-cli/wp-cli/pull/1677
